### PR TITLE
Create M, implicit operator P(C value)

### DIFF
--- a/VAC/Math_Module/LMath_C/C.cs
+++ b/VAC/Math_Module/LMath_C/C.cs
@@ -299,7 +299,7 @@ namespace LMath
                     s = s.Replace(" ", "");
                     bool flag1 = s[0] == '-';
                     bool flag2 = true;
-                    if (!flag1)
+                    if (flag1)
                     {
                         s = s.Remove(0, 1);
                     }

--- a/VAC/Math_Module/LMath_M/M.cs
+++ b/VAC/Math_Module/LMath_M/M.cs
@@ -235,11 +235,6 @@ namespace LMath
             return oneness;
         }
 
-        public static M Create(string s)
-        {
-            return null;
-        }
-
         #endregion
 
         #region Событие
@@ -365,6 +360,21 @@ namespace LMath
                 return elements[0, 0].Clone();
             }
             return this;
+        }
+
+        public static M Create(string s)
+        {
+            string[] str = s.Split('_');
+            M result = new M(str[0].Split('|').Length, str.Length);
+            for (int y = 0; y < result.h; y++)
+            {
+                string[] elements = str[y].Split('|');
+                for (int x = 0; x < result.elements.Length/result.h; x++)
+                {
+                    result.elements[y, x] = P.Create(elements[x]);
+                }
+            }
+            return result;
         }
 
         public override byte COM(Math_Field second)

--- a/VAC/Math_Module/LMath_P/P.cs
+++ b/VAC/Math_Module/LMath_P/P.cs
@@ -337,10 +337,6 @@ namespace LMath
             return result;
         }
 
-        public static implicit operator List<List<string>[]>(P value)
-        {
-            return null;
-        }
 
         public static implicit operator List<string>(P value)
         {
@@ -349,7 +345,11 @@ namespace LMath
 
         public static implicit operator P(C value)
         {
-            return null;
+            P result = new P();
+            M monom = new M();
+            monom.coef = value.Clone() as C;
+            result.Ms.Add(monom);
+            return result;
         }
 
         public static explicit operator C(P value)//сломано


### PR DESCRIPTION
Реализовали вместе Create в M, исправил ещё Create в C (там просто один символ удалить нужно было, хз почему он там стоял). Начал реализовывать приведение типов, от C в P сделал, а вот от P в С не исправил, не знаю что там поломано, вроде isDown проходит все тесты, тут мои полномочия всё (ну не всё, я просто потом у тебя спрошу что может быть не так). Ну и приведение в List<string> от P тоже пока не сделал, для этого сначала нужно реализовать подобное в С, которого там, почему-то, нет.